### PR TITLE
:children_crossing: change API create toast

### DIFF
--- a/examples/components/toast/toast.container.js
+++ b/examples/components/toast/toast.container.js
@@ -5,11 +5,11 @@ import { create } from '../../../src/toast/redux'
 
 const mapDispatchToProps = (dispatch) => {
   return {
-    onClickDefault: () => dispatch(create({ code: 'toast1', title: 'Default' })),
-    onClickSuccess: () => dispatch(create({ code: 'toast2', title: 'Success', type: 'success' })),
-    onClickWarning: () => dispatch(create({ code: 'toast3', title: 'Warning', type: 'warning' })),
-    onClickError: () => dispatch(create({ code: 'toast4', title: 'Error', type: 'error' })),
-    onClickButton: () => dispatch(create({ code: 'toast5', title: 'With Button', button: { text: 'cancel', onClick: () => console.log('my action') } })),
+    onClickDefault: () => dispatch(create('Default :|')),
+    onClickSuccess: () => dispatch(create.success('Success :D')),
+    onClickWarning: () => dispatch(create.warning('Warning :/')),
+    onClickError: () => dispatch(create.error('Error :(')),
+    onClickButton: () => dispatch(create('With Button :)', { button: { text: 'cancel', onClick: () => console.log('my action') } })),
   }
 }
 

--- a/examples/components/toast/toast.container.js
+++ b/examples/components/toast/toast.container.js
@@ -7,7 +7,7 @@ const mapDispatchToProps = (dispatch) => {
   return {
     onClickDefault: () => dispatch(create('Default :|')),
     onClickSuccess: () => dispatch(create.success('Success :D')),
-    onClickWarning: () => dispatch(create.warning('Warning :/')),
+    onClickWarning: () => dispatch(create('Warning :/', { type: 'warning' })),
     onClickError: () => dispatch(create.error('Error :(')),
     onClickButton: () => dispatch(create('With Button :)', { button: { text: 'cancel', onClick: () => console.log('my action') } })),
   }

--- a/lib/toast/button/button.js
+++ b/lib/toast/button/button.js
@@ -45,7 +45,7 @@ Button.propTypes = {
   className: _propTypes2.default.string,
   text: _propTypes2.default.string,
   onClick: _propTypes2.default.func,
-  type: _propTypes2.default.oneOf(['', 'success', 'warning', 'error'])
+  type: _propTypes2.default.oneOf(['default', 'success', 'warning', 'error'])
 };
 
 Button.defaultProps = {
@@ -53,7 +53,7 @@ Button.defaultProps = {
   className: '',
   text: '',
   onClick: undefined,
-  type: ''
+  type: 'default'
 };
 
 exports.default = (0, _recompose.onlyUpdateForPropTypes)(Button);

--- a/lib/toast/hoc/toast.js
+++ b/lib/toast/hoc/toast.js
@@ -21,11 +21,12 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 var addDelay = exports.addDelay = function addDelay(prevProps, props, defaultDelay, timer) {
   var print = props.print,
-      code = props.code,
+      title = props.title,
+      type = props.type,
       remove = props.remove,
       delay = props.delay;
 
-  if (prevProps.code !== code && print) {
+  if ((prevProps.title !== title || prevProps.type !== type) && print) {
     if (timer) clearTimeout(timer);
     return setTimeout(remove, delay || defaultDelay);
   }

--- a/lib/toast/hoc/toast.js
+++ b/lib/toast/hoc/toast.js
@@ -20,13 +20,12 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var addDelay = exports.addDelay = function addDelay(prevProps, props, defaultDelay, timer) {
-  var print = props.print,
-      title = props.title,
+  var title = props.title,
       type = props.type,
       remove = props.remove,
       delay = props.delay;
 
-  if ((prevProps.title !== title || prevProps.type !== type) && print) {
+  if (prevProps.title !== title || prevProps.type !== type) {
     if (timer) clearTimeout(timer);
     return setTimeout(remove, delay || defaultDelay);
   }

--- a/lib/toast/redux/toast.actions.js
+++ b/lib/toast/redux/toast.actions.js
@@ -17,10 +17,9 @@ var action = function action(type) {
 var create = exports.create = function create(title, options) {
   return action()(title, options);
 };
-Object.assign(create, {
-  success: action('success'),
-  warning: action('warning'),
-  error: action('error')
+var types = ['success', 'warning', 'error'];
+types.forEach(function (type) {
+  create[type] = action(type);
 });
 
 var REMOVE_TOAST = exports.REMOVE_TOAST = 'REMOVE_TOAST';

--- a/lib/toast/redux/toast.actions.js
+++ b/lib/toast/redux/toast.actions.js
@@ -3,10 +3,25 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
 var CREATE_TOAST = exports.CREATE_TOAST = 'CREATE_TOAST';
-var create = exports.create = function create(payload) {
-  return { type: CREATE_TOAST, payload: payload };
+
+var action = function action(type) {
+  return function (title, options) {
+    return { type: CREATE_TOAST, payload: _extends({ title: title, type: type }, options) };
+  };
 };
+
+var create = exports.create = function create(title, options) {
+  return action()(title, options);
+};
+Object.assign(create, {
+  success: action('success'),
+  warning: action('warning'),
+  error: action('error')
+});
 
 var REMOVE_TOAST = exports.REMOVE_TOAST = 'REMOVE_TOAST';
 var remove = exports.remove = function remove() {

--- a/lib/toast/toast.js
+++ b/lib/toast/toast.js
@@ -62,7 +62,7 @@ Toast.propTypes = {
   title: _propTypes2.default.string,
   button: _propTypes2.default.object,
   position: _propTypes2.default.oneOf(['top', 'bottom']),
-  type: _propTypes2.default.oneOf(['', 'success', 'warning', 'error'])
+  type: _propTypes2.default.oneOf(['default', 'success', 'warning', 'error'])
 };
 
 Toast.defaultProps = {
@@ -70,9 +70,9 @@ Toast.defaultProps = {
   className: '',
   print: false,
   title: '',
-  button: {},
+  button: undefined,
   position: 'bottom',
-  type: ''
+  type: 'default'
 };
 
 exports.default = (0, _recompose.onlyUpdateForPropTypes)(Toast);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kriya",
-  "version": "2.6.2",
+  "version": "2.7.0",
   "main": "index.js",
   "description": "Kriya is a react/redux components library",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kriya",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "main": "index.js",
   "description": "Kriya is a react/redux components library",
   "license": "MIT",

--- a/src/toast/__snapshots__/toast.spec.js.snap
+++ b/src/toast/__snapshots__/toast.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`common/Toast container should pass position when it's defined in props 1`] = `
 <div
-  className="toast top"
+  className="toast top default"
   style={Object {}}
 >
   <span
@@ -10,17 +10,12 @@ exports[`common/Toast container should pass position when it's defined in props 
   >
     
   </span>
-  <div
-    className="button"
-  >
-    {"name":"button","props":{"type":""}}
-  </div>
 </div>
 `;
 
 exports[`common/Toast graphical (JSX) should add button 1`] = `
 <div
-  className="toast bottom"
+  className="toast bottom default"
   style={Object {}}
 >
   <span
@@ -31,14 +26,14 @@ exports[`common/Toast graphical (JSX) should add button 1`] = `
   <div
     className="button"
   >
-    {"name":"button","props":{"title":"my button","type":""}}
+    {"name":"button","props":{"title":"my button","type":"default"}}
   </div>
 </div>
 `;
 
 exports[`common/Toast graphical (JSX) should add button and onClick 1`] = `
 <div
-  className="toast bottom"
+  className="toast bottom default"
   style={Object {}}
 >
   <span
@@ -49,14 +44,14 @@ exports[`common/Toast graphical (JSX) should add button and onClick 1`] = `
   <div
     className="button"
   >
-    {"name":"button","props":{"title":"my button","type":""}}
+    {"name":"button","props":{"title":"my button","type":"default"}}
   </div>
 </div>
 `;
 
 exports[`common/Toast graphical (JSX) should add custom className 1`] = `
 <div
-  className="toast custom bottom"
+  className="toast custom bottom default"
   style={Object {}}
 >
   <span
@@ -64,17 +59,12 @@ exports[`common/Toast graphical (JSX) should add custom className 1`] = `
   >
     
   </span>
-  <div
-    className="button"
-  >
-    {"name":"button","props":{"type":""}}
-  </div>
 </div>
 `;
 
 exports[`common/Toast graphical (JSX) should add custom delay 1`] = `
 <div
-  className="toast bottom"
+  className="toast bottom default"
   style={Object {}}
 >
   <span
@@ -82,17 +72,12 @@ exports[`common/Toast graphical (JSX) should add custom delay 1`] = `
   >
     
   </span>
-  <div
-    className="button"
-  >
-    {"name":"button","props":{"type":""}}
-  </div>
 </div>
 `;
 
 exports[`common/Toast graphical (JSX) should add custom position 1`] = `
 <div
-  className="toast top"
+  className="toast top default"
   style={Object {}}
 >
   <span
@@ -100,17 +85,12 @@ exports[`common/Toast graphical (JSX) should add custom position 1`] = `
   >
     
   </span>
-  <div
-    className="button"
-  >
-    {"name":"button","props":{"type":""}}
-  </div>
 </div>
 `;
 
 exports[`common/Toast graphical (JSX) should add custom style 1`] = `
 <div
-  className="toast bottom"
+  className="toast bottom default"
   style={
     Object {
       "backgroundColor": "red",
@@ -122,11 +102,6 @@ exports[`common/Toast graphical (JSX) should add custom style 1`] = `
   >
     
   </span>
-  <div
-    className="button"
-  >
-    {"name":"button","props":{"type":""}}
-  </div>
 </div>
 `;
 
@@ -140,17 +115,12 @@ exports[`common/Toast graphical (JSX) should add custom type 1`] = `
   >
     
   </span>
-  <div
-    className="button"
-  >
-    {"name":"button","props":{"type":"warning"}}
-  </div>
 </div>
 `;
 
 exports[`common/Toast graphical (JSX) should add title 1`] = `
 <div
-  className="toast bottom"
+  className="toast bottom default"
   style={Object {}}
 >
   <span
@@ -158,17 +128,12 @@ exports[`common/Toast graphical (JSX) should add title 1`] = `
   >
     my awesome title
   </span>
-  <div
-    className="button"
-  >
-    {"name":"button","props":{"type":""}}
-  </div>
 </div>
 `;
 
 exports[`common/Toast graphical (JSX) should have a default behaviour 1`] = `
 <div
-  className="toast bottom"
+  className="toast bottom default"
   style={Object {}}
 >
   <span
@@ -176,17 +141,12 @@ exports[`common/Toast graphical (JSX) should have a default behaviour 1`] = `
   >
     
   </span>
-  <div
-    className="button"
-  >
-    {"name":"button","props":{"type":""}}
-  </div>
 </div>
 `;
 
 exports[`common/Toast graphical (JSX) should print toast 1`] = `
 <div
-  className="toast bottom print"
+  className="toast bottom default print"
   style={Object {}}
 >
   <span
@@ -194,10 +154,5 @@ exports[`common/Toast graphical (JSX) should print toast 1`] = `
   >
     
   </span>
-  <div
-    className="button"
-  >
-    {"name":"button","props":{"type":""}}
-  </div>
 </div>
 `;

--- a/src/toast/button/__snapshots__/button.spec.js.snap
+++ b/src/toast/button/__snapshots__/button.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`common/Button graphical (JSX) should add custom className 1`] = `
 <button
-  className="button custom"
+  className="button default custom"
   onClick={undefined}
   style={Object {}}
 >
@@ -12,7 +12,7 @@ exports[`common/Button graphical (JSX) should add custom className 1`] = `
 
 exports[`common/Button graphical (JSX) should add custom style 1`] = `
 <button
-  className="button"
+  className="button default"
   onClick={undefined}
   style={
     Object {
@@ -36,7 +36,7 @@ exports[`common/Button graphical (JSX) should add custom type 1`] = `
 
 exports[`common/Button graphical (JSX) should add handler 1`] = `
 <button
-  className="button"
+  className="button default"
   onClick={[Function]}
   style={Object {}}
 >
@@ -46,7 +46,7 @@ exports[`common/Button graphical (JSX) should add handler 1`] = `
 
 exports[`common/Button graphical (JSX) should add text 1`] = `
 <button
-  className="button"
+  className="button default"
   onClick={undefined}
   style={Object {}}
 >

--- a/src/toast/button/button.jsx
+++ b/src/toast/button/button.jsx
@@ -23,7 +23,7 @@ Button.propTypes = {
   className: PropTypes.string,
   text: PropTypes.string,
   onClick: PropTypes.func,
-  type: PropTypes.oneOf(['', 'success', 'warning', 'error']),
+  type: PropTypes.oneOf(['default', 'success', 'warning', 'error']),
 }
 
 Button.defaultProps = {
@@ -31,7 +31,7 @@ Button.defaultProps = {
   className: '',
   text: '',
   onClick: undefined,
-  type: '',
+  type: 'default',
 }
 
 export default onlyUpdateForPropTypes(Button)

--- a/src/toast/hoc/toast.jsx
+++ b/src/toast/hoc/toast.jsx
@@ -1,8 +1,8 @@
 import React, { Component } from 'react'
 
 export const addDelay = (prevProps, props, defaultDelay, timer) => {
-  const { print, title, type, remove, delay } = props
-  if ((prevProps.title !== title || prevProps.type !== type) && print) {
+  const { title, type, remove, delay } = props
+  if (prevProps.title !== title || prevProps.type !== type) {
     if (timer) clearTimeout(timer)
     return setTimeout(remove, delay || defaultDelay)
   }

--- a/src/toast/hoc/toast.jsx
+++ b/src/toast/hoc/toast.jsx
@@ -1,8 +1,8 @@
 import React, { Component } from 'react'
 
 export const addDelay = (prevProps, props, defaultDelay, timer) => {
-  const { print, code, remove, delay } = props
-  if (prevProps.code !== code && print) {
+  const { print, title, type, remove, delay } = props
+  if ((prevProps.title !== title || prevProps.type !== type) && print) {
     if (timer) clearTimeout(timer)
     return setTimeout(remove, delay || defaultDelay)
   }

--- a/src/toast/hoc/toast.spec.js
+++ b/src/toast/hoc/toast.spec.js
@@ -8,13 +8,14 @@
 
 import { addDelay } from './toast'
 
+const props = remove => ({ title: 'title', type: 'success', print: true, remove })
+
 describe('HOC', () => {
   it('should call remove when delay is done', () => {
     jest.useFakeTimers()
     const remove = jest.fn()
     const prevProps = {}
-    const props = { code: 'newToast', remove, print: true }
-    addDelay(prevProps, props, 3000)
+    addDelay(prevProps, props(remove), 3000)
     jest.runAllTimers()
     expect(remove.mock.calls.length).toBe(1)
     jest.clearAllTimers()
@@ -22,9 +23,7 @@ describe('HOC', () => {
   it('should not call remove if the current toast is already print', () => {
     jest.useFakeTimers()
     const remove = jest.fn()
-    const prevProps = { code: 'toast1', remove, print: true }
-    const props = { code: 'toast1', remove, print: true }
-    addDelay(prevProps, props, 3000)
+    addDelay(props(remove), props(remove), 3000)
     jest.runAllTimers()
     expect(remove.mock.calls.length).toBe(0)
     jest.clearAllTimers()
@@ -33,9 +32,8 @@ describe('HOC', () => {
     jest.useFakeTimers()
     const handler = jest.fn()
     const remove = jest.fn()
-    const prevProps = { code: 'toast1', remove, print: true }
-    const props = { code: 'toast2', remove, print: true }
-    addDelay(prevProps, props, 3000, setTimeout(handler, 5000))
+    const prevProps = props(remove)
+    addDelay(prevProps, { ...props(remove), title: 'title2' }, 3000, setTimeout(handler, 5000))
     jest.runAllTimers()
     expect(clearTimeout).toHaveBeenCalledTimes(1)
     expect(handler).toHaveBeenCalledTimes(0)

--- a/src/toast/redux/toast.actions.js
+++ b/src/toast/redux/toast.actions.js
@@ -5,12 +5,8 @@ const action = type =>
   ({ type: CREATE_TOAST, payload: { title, type, ...options } })
 
 export const create = (title, options) => action()(title, options)
-Object.assign(create, {
-  success: action('success'),
-  warning: action('warning'),
-  error: action('error'),
-})
-
+const types = ['success', 'warning', 'error']
+types.forEach((type) => { create[type] = action(type) })
 
 export const REMOVE_TOAST = 'REMOVE_TOAST'
 export const remove = () => ({ type: REMOVE_TOAST })

--- a/src/toast/redux/toast.actions.js
+++ b/src/toast/redux/toast.actions.js
@@ -1,5 +1,16 @@
 export const CREATE_TOAST = 'CREATE_TOAST'
-export const create = payload => ({ type: CREATE_TOAST, payload })
+
+const action = type =>
+  (title, options) =>
+  ({ type: CREATE_TOAST, payload: { title, type, ...options } })
+
+export const create = (title, options) => action()(title, options)
+Object.assign(create, {
+  success: action('success'),
+  warning: action('warning'),
+  error: action('error'),
+})
+
 
 export const REMOVE_TOAST = 'REMOVE_TOAST'
 export const remove = () => ({ type: REMOVE_TOAST })

--- a/src/toast/redux/toast.spec.js
+++ b/src/toast/redux/toast.spec.js
@@ -7,7 +7,7 @@ import { create, remove } from './toast.actions'
 const state = {
   ui: {
     toast: {
-      code: 'toast1', print: true, title: 'my toast with button', button: { text: 'my button', handler: () => 'test' }
+      print: true, title: 'my toast with button', button: { text: 'my button', handler: () => 'test' }
     }
   }
 }
@@ -30,8 +30,8 @@ describe('toast/redux', () => {
         .toBe(state)
     )
     it('should create a toast', () =>
-      expect(reducer(state.ui.toast, create({ code: 'toast1', title: 'new toast', type: 'error' })))
-        .toEqual({ code: 'toast1', title: 'new toast', type: 'error', print: true })
+      expect(reducer(state.ui.toast, create.error('new toast')))
+        .toEqual({ title: 'new toast', type: 'error', print: true })
     )
     it('should remove a toast', () =>
       expect(reducer(state.ui.toast, remove()))

--- a/src/toast/redux/toast.spec.js
+++ b/src/toast/redux/toast.spec.js
@@ -29,7 +29,11 @@ describe('toast/redux', () => {
       expect(reducer(state, { type: 'UNKNOWN' }))
         .toBe(state)
     )
-    it('should create a toast', () =>
+    it('should create a toast with type option', () =>
+      expect(reducer(state.ui.toast, create('success toast', { type: 'success' })))
+        .toEqual({ title: 'success toast', type: 'success', print: true })
+    )
+    it('should create a toast with factory', () =>
       expect(reducer(state.ui.toast, create.error('new toast')))
         .toEqual({ title: 'new toast', type: 'error', print: true })
     )

--- a/src/toast/redux/toast.spec.js
+++ b/src/toast/redux/toast.spec.js
@@ -37,6 +37,10 @@ describe('toast/redux', () => {
       expect(reducer(state.ui.toast, create.error('new toast')))
         .toEqual({ title: 'new toast', type: 'error', print: true })
     )
+    it('should create a default toast with factory', () =>
+      expect(reducer(state.ui.toast, create('default toast')))
+        .toEqual({ title: 'default toast', print: true })
+    )
     it('should remove a toast', () =>
       expect(reducer(state.ui.toast, remove()))
         .toEqual({})

--- a/src/toast/toast.jsx
+++ b/src/toast/toast.jsx
@@ -31,7 +31,7 @@ Toast.propTypes = {
   title: PropTypes.string,
   button: PropTypes.object,
   position: PropTypes.oneOf(['top', 'bottom']),
-  type: PropTypes.oneOf(['', 'success', 'warning', 'error']),
+  type: PropTypes.oneOf(['default', 'success', 'warning', 'error']),
 }
 
 Toast.defaultProps = {
@@ -39,9 +39,9 @@ Toast.defaultProps = {
   className: '',
   print: false,
   title: '',
-  button: {},
+  button: undefined,
   position: 'bottom',
-  type: '',
+  type: 'default',
 }
 
 export default onlyUpdateForPropTypes(Toast)

--- a/src/toast/toast.spec.js
+++ b/src/toast/toast.spec.js
@@ -53,7 +53,7 @@ describe('common/Toast', () => {
     it("should pass position when it's defined in props", () => snapContainer({}, { position: 'top' }))
     it(`should dispatch ${REMOVE_TOAST} when remove is called`, () => {
       const dispatch = jest.fn()
-      const store = createStore(() => ({ ui: { toast: { code: 'toast1', print: true, title: 'toast' } } }))
+      const store = createStore(() => ({ ui: { toast: { print: true, title: 'toast' } } }))
       store.dispatch = dispatch
       const container = createContainer(store)
       container.find(Toast).props().remove()


### PR DESCRIPTION
I think, UX is better with this API : 

before : 
```es6
create({ title: 'Default :|', type: 'default' })
create({ title: 'Success :D', type: 'success' })
create({ title: 'With Button :)', type: 'default', button: { text: 'cancel', onClick: () => ... } })
```

after : 
```es6
create('Default :|')
create.success('Success :D')
create('With Button :)', { button: { text: 'cancel', onClick: () => ... } })
```

I have removed the property `code` because it's obviously, toast is identify by `type` and `title`