### PR TITLE
:bug: Touched input fields and custom required message

### DIFF
--- a/lib/input/input.container.js
+++ b/lib/input/input.container.js
@@ -21,14 +21,18 @@ var mapStateToProps = function mapStateToProps(state, _ref) {
       name = _ref.name,
       placeholder = _ref.placeholder,
       label = _ref.label,
-      withoutLabel = _ref.withoutLabel;
+      withoutLabel = _ref.withoutLabel,
+      forceTouch = _ref.forceTouch;
 
   var error = (0, _reduxForm.getFormSyncErrors)(form)(state);
   var value = (0, _reduxForm.formValueSelector)(form)(state, name);
 
+  var meta = (0, _reduxForm.getFormMeta)(form)(state);
+  var isTouched = forceTouch || meta && meta[name] && meta[name].touched;
+
   return {
     value: value,
-    error: error ? error[name] : undefined,
+    error: isTouched && error ? error[name] : undefined,
     label: !withoutLabel && (label || placeholder),
     hiddenLabel: !label && (!value || Array.isArray(value) && value.length === 0)
   };

--- a/lib/input/input.js
+++ b/lib/input/input.js
@@ -57,8 +57,10 @@ var getComponent = function getComponent(type) {
   }
 };
 
-var validateRequired = function validateRequired(value) {
-  return value ? undefined : 'required';
+var validateRequired = function validateRequired(requiredMessage) {
+  return function (value) {
+    return value ? undefined : requiredMessage || 'required';
+  };
 };
 
 var types = ['checkbox', 'color', 'date', 'datetime-local', 'email', 'month', 'number', 'password', 'radio', 'range', 'search', 'select', 'selectbox', 'tel', 'text', 'textarea', 'time', 'url', 'week'];
@@ -81,8 +83,8 @@ var Input = function Input(_ref) {
       creatable = _ref.creatable,
       loadOptions = _ref.loadOptions,
       error = _ref.error,
-      validate = _ref.validate,
-      selectboxProps = _objectWithoutProperties(_ref, ['className', 'style', 'type', 'name', 'label', 'placeholder', 'disabled', 'required', 'options', 'value', 'hiddenLabel', 'asynch', 'creatable', 'loadOptions', 'error', 'validate']);
+      requiredMessage = _ref.requiredMessage,
+      selectboxProps = _objectWithoutProperties(_ref, ['className', 'style', 'type', 'name', 'label', 'placeholder', 'disabled', 'required', 'options', 'value', 'hiddenLabel', 'asynch', 'creatable', 'loadOptions', 'error', 'requiredMessage']);
 
   var classes = (0, _classnames5.default)(_inputStyles2.default.input, _defineProperty({}, _inputStyles2.default.showLabel, !hiddenLabel), _inputStyles2.default['type-' + type], className);
 
@@ -99,7 +101,8 @@ var Input = function Input(_ref) {
     className: (0, _classnames5.default)(_defineProperty({}, _inputStyles2.default.error, !!error))
   }, commonProps, selectboxProps));
 
-  if (required) validate.push(validateRequired);
+  var validate = [];
+  if (required) validate.push(validateRequired(requiredMessage));
   var field = _react2.default.createElement(
     _reduxForm.Field,
     _extends({
@@ -162,7 +165,7 @@ Input.propTypes = {
   onInputChange: _propTypes2.default.func,
   loadOptions: _propTypes2.default.func,
   error: _propTypes2.default.any,
-  validate: _propTypes2.default.array
+  requiredMessage: _propTypes2.default.string
 };
 
 Input.defaultProps = {
@@ -182,7 +185,7 @@ Input.defaultProps = {
   onInputChange: undefined,
   loadOptions: undefined,
   error: false,
-  validate: []
+  requiredMessage: ''
 };
 
 exports.default = (0, _recompose.onlyUpdateForPropTypes)(Input);

--- a/lib/input/input.js
+++ b/lib/input/input.js
@@ -81,7 +81,8 @@ var Input = function Input(_ref) {
       creatable = _ref.creatable,
       loadOptions = _ref.loadOptions,
       error = _ref.error,
-      selectboxProps = _objectWithoutProperties(_ref, ['className', 'style', 'type', 'name', 'label', 'placeholder', 'disabled', 'required', 'options', 'value', 'hiddenLabel', 'asynch', 'creatable', 'loadOptions', 'error']);
+      validate = _ref.validate,
+      selectboxProps = _objectWithoutProperties(_ref, ['className', 'style', 'type', 'name', 'label', 'placeholder', 'disabled', 'required', 'options', 'value', 'hiddenLabel', 'asynch', 'creatable', 'loadOptions', 'error', 'validate']);
 
   var classes = (0, _classnames5.default)(_inputStyles2.default.input, _defineProperty({}, _inputStyles2.default.showLabel, !hiddenLabel), _inputStyles2.default['type-' + type], className);
 
@@ -98,7 +99,6 @@ var Input = function Input(_ref) {
     className: (0, _classnames5.default)(_defineProperty({}, _inputStyles2.default.error, !!error))
   }, commonProps, selectboxProps));
 
-  var validate = [];
   if (required) validate.push(validateRequired);
   var field = _react2.default.createElement(
     _reduxForm.Field,
@@ -161,7 +161,8 @@ Input.propTypes = {
   onChange: _propTypes2.default.func,
   onInputChange: _propTypes2.default.func,
   loadOptions: _propTypes2.default.func,
-  error: _propTypes2.default.any
+  error: _propTypes2.default.any,
+  validate: _propTypes2.default.array
 };
 
 Input.defaultProps = {
@@ -180,7 +181,8 @@ Input.defaultProps = {
   onChange: undefined,
   onInputChange: undefined,
   loadOptions: undefined,
-  error: false
+  error: false,
+  validate: []
 };
 
 exports.default = (0, _recompose.onlyUpdateForPropTypes)(Input);

--- a/src/input/input.container.js
+++ b/src/input/input.container.js
@@ -1,15 +1,18 @@
 import { connect } from 'react-redux'
-import { change, formValueSelector, getFormSyncErrors } from 'redux-form'
+import { change, formValueSelector, getFormSyncErrors, getFormMeta } from 'redux-form'
 import { formInjector } from '../helpers'
 import Component from './input'
 
-const mapStateToProps = (state, { form, name, placeholder, label, withoutLabel }) => {
+const mapStateToProps = (state, { form, name, placeholder, label, withoutLabel, forceTouch }) => {
   const error = getFormSyncErrors(form)(state)
   const value = formValueSelector(form)(state, name)
 
+  const meta = getFormMeta(form)(state)
+  const isTouched = forceTouch || (meta && meta[name] && meta[name].touched)
+
   return {
     value,
-    error: error ? error[name] : undefined,
+    error: isTouched && error ? error[name] : undefined,
     label: !withoutLabel && (label || placeholder),
     hiddenLabel: !label && (!value || (Array.isArray(value) && value.length === 0)),
   }

--- a/src/input/input.jsx
+++ b/src/input/input.jsx
@@ -47,7 +47,7 @@ const Input = ({
   placeholder, disabled,
   required, options, value, hiddenLabel,
   asynch, creatable, loadOptions,
-  error,
+  error, validate,
   ...selectboxProps
  }) => {
   const classes = classnames(
@@ -76,7 +76,6 @@ const Input = ({
     />
   )
 
-  const validate = []
   if (required) validate.push(validateRequired)
   const field = (
     <Field
@@ -129,6 +128,7 @@ Input.propTypes = {
   onInputChange: PropTypes.func,
   loadOptions: PropTypes.func,
   error: PropTypes.any,
+  validate: PropTypes.array,
 }
 
 Input.defaultProps = {
@@ -148,6 +148,7 @@ Input.defaultProps = {
   onInputChange: undefined,
   loadOptions: undefined,
   error: false,
+  validate: [],
 }
 
 export default onlyUpdateForPropTypes(Input)

--- a/src/input/input.jsx
+++ b/src/input/input.jsx
@@ -17,7 +17,7 @@ const getComponent = (type) => {
   }
 }
 
-const validateRequired = value => (value ? undefined : 'required')
+const validateRequired = requiredMessage => value => (value ? undefined : requiredMessage || 'required')
 
 const types = [
   'checkbox',
@@ -47,7 +47,7 @@ const Input = ({
   placeholder, disabled,
   required, options, value, hiddenLabel,
   asynch, creatable, loadOptions,
-  error, validate,
+  error, requiredMessage,
   ...selectboxProps
  }) => {
   const classes = classnames(
@@ -76,7 +76,8 @@ const Input = ({
     />
   )
 
-  if (required) validate.push(validateRequired)
+  const validate = []
+  if (required) validate.push(validateRequired(requiredMessage))
   const field = (
     <Field
       className={classnames({ [styles.error]: !!error, [styles.field]: type !== 'checkbox' })}
@@ -128,7 +129,7 @@ Input.propTypes = {
   onInputChange: PropTypes.func,
   loadOptions: PropTypes.func,
   error: PropTypes.any,
-  validate: PropTypes.array,
+  requiredMessage: PropTypes.string,
 }
 
 Input.defaultProps = {
@@ -148,7 +149,7 @@ Input.defaultProps = {
   onInputChange: undefined,
   loadOptions: undefined,
   error: false,
-  validate: [],
+  requiredMessage: '',
 }
 
 export default onlyUpdateForPropTypes(Input)


### PR DESCRIPTION
- Now handles touched and untouched fields to display errors :
  - if the field is untouched, the error message won't be displayed
  - if the field is touched or if the form is submitted, then the error message will be displayed

- The default "required" error message can now be changed by passing `requiredMessage` to the Input component