### PR TITLE
:bug: fields are not being re-registered by redux-form

### DIFF
--- a/examples/components/input/input.jsx
+++ b/examples/components/input/input.jsx
@@ -18,6 +18,9 @@ const Form = ({ style, className }) => {
     className,
   )
 
+  const inputValidate = [value => (value ? undefined : 'You don\'t really have a brain, do you?')]
+  const textAreaValidate = [value => (value ? undefined : 'Rethorical question, don\'t answer it.')]
+
   return (
     <form
       className={classes}
@@ -26,6 +29,7 @@ const Form = ({ style, className }) => {
     >
       <h1>Examples INPUT</h1>
       {/* form input */}
+      <h2>General examples</h2>
       <div>
         <Input placeholder="input" name="input" required label="Input label" />
         <Input type="text" placeholder="input2" name="input2" />
@@ -41,6 +45,16 @@ const Form = ({ style, className }) => {
       <div>
         <Input type="selectbox" placeholder="selectbox creatable" name="selectbox_creatable" options={stringOptions} creatable promptTextCreator={e => `Add ${e}`} />
         <Input type="selectbox" placeholder="selectbox creatable" name="selectbox_creatable_multi" options={stringOptions} creatable promptTextCreator={e => `"${e}" add to family`} multi />
+      </div>
+      <h2>Required INPUT</h2>
+      <div>
+        <Input name="defaultRequiredInput" label="Default required input" placeholder="Any idea?" required />
+        <Input name="customRequiredInput" label="Custom required input" placeholder="Thoughts??" required validate={inputValidate} />
+        <Input name="defaultRequiredTextarea" label="Default required Text area" placeholder="Anything???" type="textarea" required />
+        <Input name="customRequiredTextarea" label="Custom required Text area" placeholder="Can you even think???!" type="textarea" required validate={textAreaValidate} />
+      </div>
+      <div>
+        <Input name="customRequiredSelectbox" label="Custom required Select box" placeholder="Can you even think???!" type="selectbox" required validate={[console.log]} options={stringOptions} />
       </div>
       <Button type="submit" primary name="SUBMIT">Submit</Button>
     </form>

--- a/lib/input/input.js
+++ b/lib/input/input.js
@@ -59,6 +59,16 @@ var getComponent = function getComponent(type) {
 
 var types = ['checkbox', 'color', 'date', 'datetime-local', 'email', 'month', 'number', 'password', 'radio', 'range', 'search', 'select', 'selectbox', 'tel', 'text', 'textarea', 'time', 'url', 'week'];
 
+/**
+ * To customize the default 'required' message, or in order to add the field level validation
+ * you have to pass a `validate` prop to the Input component, which will override it.
+ *
+ * NB: `redux-form` perform 'unregister_field' then 'register_field'
+ * whenever the validate prop changes.
+ * So, to avoid breaking the validation process (form or field level),
+ * `validate` props should be declared as constants outside of any Component.
+ * You can look at the example part of this project to see how it's done.
+ */
 var validateRequired = [function (value) {
   return value ? undefined : 'required';
 }];

--- a/lib/input/input.js
+++ b/lib/input/input.js
@@ -57,13 +57,11 @@ var getComponent = function getComponent(type) {
   }
 };
 
-var validateRequired = function validateRequired(requiredMessage) {
-  return function (value) {
-    return value ? undefined : requiredMessage || 'required';
-  };
-};
-
 var types = ['checkbox', 'color', 'date', 'datetime-local', 'email', 'month', 'number', 'password', 'radio', 'range', 'search', 'select', 'selectbox', 'tel', 'text', 'textarea', 'time', 'url', 'week'];
+
+var validateRequired = [function (value) {
+  return value ? undefined : 'required';
+}];
 
 var Input = function Input(_ref) {
   var _classnames3;
@@ -83,8 +81,8 @@ var Input = function Input(_ref) {
       creatable = _ref.creatable,
       loadOptions = _ref.loadOptions,
       error = _ref.error,
-      requiredMessage = _ref.requiredMessage,
-      selectboxProps = _objectWithoutProperties(_ref, ['className', 'style', 'type', 'name', 'label', 'placeholder', 'disabled', 'required', 'options', 'value', 'hiddenLabel', 'asynch', 'creatable', 'loadOptions', 'error', 'requiredMessage']);
+      validate = _ref.validate,
+      selectboxProps = _objectWithoutProperties(_ref, ['className', 'style', 'type', 'name', 'label', 'placeholder', 'disabled', 'required', 'options', 'value', 'hiddenLabel', 'asynch', 'creatable', 'loadOptions', 'error', 'validate']);
 
   var classes = (0, _classnames5.default)(_inputStyles2.default.input, _defineProperty({}, _inputStyles2.default.showLabel, !hiddenLabel), _inputStyles2.default['type-' + type], className);
 
@@ -101,15 +99,13 @@ var Input = function Input(_ref) {
     className: (0, _classnames5.default)(_defineProperty({}, _inputStyles2.default.error, !!error))
   }, commonProps, selectboxProps));
 
-  var validate = [];
-  if (required) validate.push(validateRequired(requiredMessage));
   var field = _react2.default.createElement(
     _reduxForm.Field,
     _extends({
       className: (0, _classnames5.default)((_classnames3 = {}, _defineProperty(_classnames3, _inputStyles2.default.error, !!error), _defineProperty(_classnames3, _inputStyles2.default.field, type !== 'checkbox'), _classnames3)),
       component: getComponent(type)
     }, commonProps, {
-      validate: validate,
+      validate: validate || (required ? validateRequired : []),
       type: type
     }),
     type === 'select' ? options.map(function (o) {
@@ -165,7 +161,7 @@ Input.propTypes = {
   onInputChange: _propTypes2.default.func,
   loadOptions: _propTypes2.default.func,
   error: _propTypes2.default.any,
-  requiredMessage: _propTypes2.default.string
+  validate: _propTypes2.default.array
 };
 
 Input.defaultProps = {
@@ -185,7 +181,7 @@ Input.defaultProps = {
   onInputChange: undefined,
   loadOptions: undefined,
   error: false,
-  requiredMessage: ''
+  validate: undefined
 };
 
 exports.default = (0, _recompose.onlyUpdateForPropTypes)(Input);

--- a/lib/input/input.js
+++ b/lib/input/input.js
@@ -62,6 +62,7 @@ var types = ['checkbox', 'color', 'date', 'datetime-local', 'email', 'month', 'n
 var validateRequired = [function (value) {
   return value ? undefined : 'required';
 }];
+var defaultValidate = [];
 
 var Input = function Input(_ref) {
   var _classnames3;
@@ -105,7 +106,7 @@ var Input = function Input(_ref) {
       className: (0, _classnames5.default)((_classnames3 = {}, _defineProperty(_classnames3, _inputStyles2.default.error, !!error), _defineProperty(_classnames3, _inputStyles2.default.field, type !== 'checkbox'), _classnames3)),
       component: getComponent(type)
     }, commonProps, {
-      validate: validate || (required ? validateRequired : []),
+      validate: validate || (required ? validateRequired : defaultValidate),
       type: type
     }),
     type === 'select' ? options.map(function (o) {

--- a/src/input/input.jsx
+++ b/src/input/input.jsx
@@ -39,6 +39,16 @@ const types = [
   'week',
 ]
 
+/**
+ * To customize the default 'required' message, or in order to add the field level validation
+ * you have to pass a `validate` prop to the Input component, which will override it.
+ *
+ * NB: `redux-form` perform 'unregister_field' then 'register_field'
+ * whenever the validate prop changes.
+ * So, to avoid breaking the validation process (form or field level),
+ * `validate` props should be declared as constants outside of any Component.
+ * You can look at the example part of this project to see how it's done.
+ */
 const validateRequired = [value => (value ? undefined : 'required')]
 const defaultValidate = []
 

--- a/src/input/input.jsx
+++ b/src/input/input.jsx
@@ -40,6 +40,7 @@ const types = [
 ]
 
 const validateRequired = [value => (value ? undefined : 'required')]
+const defaultValidate = []
 
 const Input = ({
   className, style,
@@ -81,7 +82,7 @@ const Input = ({
       className={classnames({ [styles.error]: !!error, [styles.field]: type !== 'checkbox' })}
       component={getComponent(type)}
       {...commonProps}
-      validate={validate || (required ? validateRequired : [])}
+      validate={validate || (required ? validateRequired : defaultValidate)}
       type={type}
     >
       {type === 'select' ? options.map(o => <option key={o.value} value={o.value}>{o.label}</option>) : null}

--- a/src/input/input.jsx
+++ b/src/input/input.jsx
@@ -17,8 +17,6 @@ const getComponent = (type) => {
   }
 }
 
-const validateRequired = requiredMessage => value => (value ? undefined : requiredMessage || 'required')
-
 const types = [
   'checkbox',
   'color',
@@ -41,13 +39,15 @@ const types = [
   'week',
 ]
 
+const validateRequired = [value => (value ? undefined : 'required')]
+
 const Input = ({
   className, style,
   type, name, label,
   placeholder, disabled,
   required, options, value, hiddenLabel,
   asynch, creatable, loadOptions,
-  error, requiredMessage,
+  error, validate,
   ...selectboxProps
  }) => {
   const classes = classnames(
@@ -76,14 +76,12 @@ const Input = ({
     />
   )
 
-  const validate = []
-  if (required) validate.push(validateRequired(requiredMessage))
   const field = (
     <Field
       className={classnames({ [styles.error]: !!error, [styles.field]: type !== 'checkbox' })}
       component={getComponent(type)}
       {...commonProps}
-      validate={validate}
+      validate={validate || (required ? validateRequired : [])}
       type={type}
     >
       {type === 'select' ? options.map(o => <option key={o.value} value={o.value}>{o.label}</option>) : null}
@@ -129,7 +127,7 @@ Input.propTypes = {
   onInputChange: PropTypes.func,
   loadOptions: PropTypes.func,
   error: PropTypes.any,
-  requiredMessage: PropTypes.string,
+  validate: PropTypes.array,
 }
 
 Input.defaultProps = {
@@ -149,7 +147,7 @@ Input.defaultProps = {
   onInputChange: undefined,
   loadOptions: undefined,
   error: false,
-  requiredMessage: '',
+  validate: undefined,
 }
 
 export default onlyUpdateForPropTypes(Input)


### PR DESCRIPTION
Default validate attribute causing fields to be re-registered and was breaking the field level validation process.

The main issue was with redux-form and its behaviour concerning field level validation, and more precisely with the validate prop.
So, each time the validate Input prop is changed, redux-form perform unregister_field and then register_field. As a (weird) consequence, it completely breaks form and field-level validation.

In order to have custom field level validation, we have to create for each field its own array of validation function, and the created array shouldn't change whenever during the component lifecycle.

I also added some examples with this behaviour, in the dedicated part of the project.