### PR TITLE
:lipstick: fix popover transition

### DIFF
--- a/src/popover/popover.styles.scss
+++ b/src/popover/popover.styles.scss
@@ -10,7 +10,7 @@
   opacity: 0;
   position: fixed;
   top: 0;
-  transition: opacity $default-transition;
+  transition: all $default-transition;
   width: 100%;
   z-index: -10;
 }


### PR DESCRIPTION
transition is applied only on opacity but there is also the z-index that change when the popover is printed or not